### PR TITLE
Legacy Python SDK (post-fork only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ each fork end up with their own instances of Statsig.
 If the parent thread notices that a fork has been alive beyond the specified timeout for some reason, it will terminate 
 all forks and restart the forking. The script will continue running until stopped. 
 
-Logs are written to `repro_wrapped_<timestamp>.log` in the current directory.
+Logs are written to `repro_post_fork_<timestamp>.log` in the current directory.
 
 ---
 

--- a/logging_config.py
+++ b/logging_config.py
@@ -9,7 +9,7 @@ def set_up_logging() -> None:
         "%(asctime)s %(levelname)s %(name)s: %(message)s"
     )
     file_handler = logging.FileHandler(
-        f"repro_wrapped_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
+        f"repro_post_fork_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(file_formatter)

--- a/repro.py
+++ b/repro.py
@@ -13,7 +13,7 @@ from statsig_interface import StatsigInterface
 logger = logging.getLogger("repro")
 
 multiprocessing.set_start_method("fork", force=True)
-StatsigInterface.initialize()
+StatsigInterface.maybe_register_at_fork_hooks()
 
 
 def _pass_through_task() -> None:

--- a/statsig_interface.py
+++ b/statsig_interface.py
@@ -35,7 +35,7 @@ class StatsigInterface:
         if not cls._at_fork_hooks_registered:
             os.register_at_fork(
                 before=cls.maybe_shutdown_statsig,
-                after_in_parent=cls._initialize_statsig,
+                after_in_parent=cls.maybe_shutdown_statsig,
                 after_in_child=cls._initialize_statsig,
             )
             cls._at_fork_hooks_registered = True


### PR DESCRIPTION
Test branch for running the repro with the [Legacy Python SDK](https://docs.statsig.com/server/pythonSDK/).

The SDK initializes only after forking.
No SDK timeouts are set.