### PR TITLE
Legacy Python SDK (post-fork only, with network timeout)

### DIFF
--- a/statsig_interface.py
+++ b/statsig_interface.py
@@ -74,7 +74,10 @@ class StatsigInterface:
             if environment == "production"
             else StatsigEnvironmentTier.development
         )
-        options = StatsigOptions(tier=tier)
+        options = StatsigOptions(
+            tier=tier,
+            timeout=3,  # seconds
+        )
 
         if not SERVER_SDK_KEY:
             options.disable_network = True


### PR DESCRIPTION
Test branch for running the repro with the [Legacy Python SDK](https://docs.statsig.com/server/pythonSDK/).

The SDK initializes only after forking.
SDK network requests have a set timeout.
